### PR TITLE
Adapts getting started guide to use most recent upstream changes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -171,9 +171,11 @@ command in the same process of the app, or a parent one.
 An inbound channel adapter listens to messages from a Google Cloud Pub/Sub subscription and sends
 them to a Spring channel in an application.
 
-Instantiating an inbound channel adapter requires a subscriber factory and the name of an existing
-subscription. The Spring Cloud GCP Pub/Sub Boot starter provides an auto-configured subscriber
-factory which you can simply inject as a method argument.
+Instantiating an inbound channel adapter requires a `PubSubOperations` instance and the name of an
+existing subscription.
+`PubSubOperations` is Spring's abstraction to subscribe to Google Cloud Pub/Sub topics.
+The Spring Cloud GCP Pub/Sub Boot starter provides an auto-configured `PubSubOperations` instance
+which you can simply inject as a method argument.
 
 `src/main/java/hello/PubSubApplication.java`
 [source,java]
@@ -214,18 +216,16 @@ the message headers.
 An outbound channel adapter listens to new messages from a Spring channel and publishes them to a
 Google Cloud Pub/Sub topic.
 
-Instantiating an outbound channel adapter requires a `PubSubTemplate`, which is Spring's abstraction
-to publish messages to Google Cloud Pub/Sub topics. The Spring Cloud GCP Pub/Sub Boot starter
-provides an auto-configured `PubSubTemplate`.
+Instantiating an outbound channel adapter requires a `PubSubOperations` and the name of an existing
+topic.
+`PubSubOperations` is Spring's abstraction to publish messages to Google Cloud Pub/Sub topics.
+The Spring Cloud GCP Pub/Sub Boot starter provides an auto-configured `PubSubOperations` instance.
 
 `src/main/java/hello/PubSubApplication.java`
 [source,java]
 ----
 include::/complete/src/main/java/hello/PubSubApplication.java[tag=messageSender]
 ----
-
-After the outbound channel adapter is instantiated, the name of the Google Cloud Pub/Sub topic
-("testTopic") where messages will be published to must be set.
 
 You can use a `MessageGateway` to write messages to a channel and publish them to Google Cloud
 Pub/Sub.
@@ -258,14 +258,14 @@ include::complete/src/main/java/hello/WebAppController.java[]
 == Authentication
 
 Your application must be authenticated either via the GOOGLE_APPLICATION_CREDENTIALS environment
-variable or the `spring.cloud.gcp.credentialsLocation` property.
+variable or the `spring.cloud.gcp.credentials.location` property.
 
 If you have the https://cloud.google.com/sdk/[Google Cloud SDK] installed, you can log in
 with your user account using the `gcloud auth application-default login` command.
 
 Alternatively, you can download a service account credentials file from the
 https://cloud.google.com/console[Google Cloud Console] and point the
-`spring.cloud.gcp.credentialsLocation` property in the `application.properties` file to it.
+`spring.cloud.gcp.credentials.location` property in the `application.properties` file to it.
 
 As a
 https://docs.spring.io/spring/docs/3.2.x/spring-framework-reference/html/resources.html[Spring Resource],

--- a/complete/src/main/java/hello/PubSubApplication.java
+++ b/complete/src/main/java/hello/PubSubApplication.java
@@ -1,23 +1,24 @@
 package hello;
 
-import com.google.cloud.pubsub.v1.AckReplyConsumer;
-import com.google.protobuf.ByteString;
 import java.io.IOException;
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.gcp.pubsub.core.PubSubOperations;
 import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
 import org.springframework.cloud.gcp.pubsub.support.GcpHeaders;
-import org.springframework.cloud.gcp.pubsub.support.SubscriberFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.gcp.AckMode;
-import org.springframework.integration.gcp.inbound.PubSubInboundChannelAdapter;
-import org.springframework.integration.gcp.outbound.PubSubMessageHandler;
+import org.springframework.integration.gcp.pubsub.AckMode;
+import org.springframework.integration.gcp.pubsub.inbound.PubSubInboundChannelAdapter;
+import org.springframework.integration.gcp.pubsub.outbound.PubSubMessageHandler;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 
@@ -43,9 +44,9 @@ public class PubSubApplication {
   @Bean
   public PubSubInboundChannelAdapter messageChannelAdapter(
       @Qualifier("pubsubInputChannel") MessageChannel inputChannel,
-      SubscriberFactory subscriberFactory) {
+      PubSubOperations pubSubTemplate) {
     PubSubInboundChannelAdapter adapter =
-        new PubSubInboundChannelAdapter(subscriberFactory, "testSubscription");
+        new PubSubInboundChannelAdapter(pubSubTemplate, "testSubscription");
     adapter.setOutputChannel(inputChannel);
     adapter.setAckMode(AckMode.MANUAL);
 
@@ -58,8 +59,7 @@ public class PubSubApplication {
   @ServiceActivator(inputChannel = "pubsubInputChannel")
   public MessageHandler messageReceiver() {
     return message -> {
-      LOGGER.info("Message arrived! Payload: "
-          + ((ByteString) message.getPayload()).toStringUtf8());
+      LOGGER.info("Message arrived! Payload: " + message.getPayload());
       AckReplyConsumer consumer =
           (AckReplyConsumer) message.getHeaders().get(GcpHeaders.ACKNOWLEDGEMENT);
       consumer.ack();
@@ -72,10 +72,8 @@ public class PubSubApplication {
   // tag::messageSender[]
   @Bean
   @ServiceActivator(inputChannel = "pubsubOutputChannel")
-  public MessageHandler messageSender(PubSubTemplate pubsubTemplate) {
-    PubSubMessageHandler outboundAdapter = new PubSubMessageHandler(pubsubTemplate);
-    outboundAdapter.setTopic("testTopic");
-    return outboundAdapter;
+  public MessageHandler messageSender(PubSubOperations pubsubTemplate) {
+    return new PubSubMessageHandler(pubsubTemplate, "testTopic");
   }
   // end::messageSender[]
 

--- a/complete/src/main/resources/application.properties
+++ b/complete/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-spring.cloud.gcp.projectId=[YOUR_GCP_PROJECT_ID_HERE]
-spring.cloud.gcp.credentialsLocation=file:[LOCAL_FS_CREDENTIALS_PATH]
+#spring.cloud.gcp.project-id=[YOUR_GCP_PROJECT_ID_HERE]
+#spring.cloud.gcp.credentials.location=file:[LOCAL_FS_CREDENTIALS_PATH]


### PR DESCRIPTION
There were some changes on the Spring Integration channel adapters
for GCP Pub/Sub that would make the example not compile.