### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -4,17 +4,17 @@ projects: [spring-cloud]
 ---
 :spring_version: current
 :spring_boot_version: 2.0.0.RC1
-:Controller: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
-:DispatcherServlet: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
-:SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
-:ResponseBody: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/bind/annotation/ResponseBody.html
+:Controller: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
+:DispatcherServlet: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
+:SpringApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
+:ResponseBody: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/bind/annotation/ResponseBody.html
 :toc:
 :icons: font
 :source-highlighter: prettify
 :project_id: gs-messaging-gcp-pubsub
 This guide walks you through the process of exchanging messages between different parts of a
 program, or different programs, using
-http://docs.spring.io/spring-integration/reference/htmlsingle/#overview-endpoints-channeladapter[Spring Integration channel adapters]
+https://docs.spring.io/spring-integration/reference/htmlsingle/#overview-endpoints-channeladapter[Spring Integration channel adapters]
 and
 https://cloud.google.com/pubsub/[Google Cloud Pub/Sub] as the underlying message exchange mechanism.
 
@@ -82,7 +82,7 @@ Or, if you're using Gradle:
 repositories {
     ...
     maven {
-        url "http://repo.spring.io/libs-milestone"
+        url "https://repo.spring.io/libs-milestone"
     }
     ...
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://docs.spring.io/spring-integration/reference/htmlsingle/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-integration/reference/htmlsingle/ ([https](https://docs.spring.io/spring-integration/reference/htmlsingle/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 3 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://repo.spring.io/libs-milestone with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 1 occurrences