### PR TITLE
Fixes Message Handler

### DIFF
--- a/complete/src/main/java/hello/PubSubApplication.java
+++ b/complete/src/main/java/hello/PubSubApplication.java
@@ -59,9 +59,9 @@ public class PubSubApplication {
   public MessageHandler messageReceiver() {
     return message -> {
       LOGGER.info("Message arrived! Payload: " + new String((byte[]) message.getPayload()));
-      AckReplyConsumer consumer =
-          (AckReplyConsumer) message.getHeaders().get(GcpPubSubHeaders.ACKNOWLEDGEMENT);
-      consumer.ack();
+      BasicAcknowledgeablePubsubMessage originalMessage =
+        message.getHeaders().get(GcpPubSubHeaders.ORIGINAL_MESSAGE, BasicAcknowledgeablePubsubMessage.class);
+      originalMessage.ack();
     };
   }
   // end::messageReceiver[]

--- a/complete/src/main/java/hello/PubSubApplication.java
+++ b/complete/src/main/java/hello/PubSubApplication.java
@@ -12,6 +12,7 @@ import org.springframework.cloud.gcp.pubsub.integration.AckMode;
 import org.springframework.cloud.gcp.pubsub.integration.inbound.PubSubInboundChannelAdapter;
 import org.springframework.cloud.gcp.pubsub.integration.outbound.PubSubMessageHandler;
 import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
+import org.springframework.cloud.gcp.pubsub.support.BasicAcknowledgeablePubsubMessage;
 import org.springframework.context.annotation.Bean;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.annotation.ServiceActivator;


### PR DESCRIPTION
Fixes #23 

Use new method to manually ack messages as described in the current documentation ([link](https://cloud.spring.io/spring-cloud-static/spring-cloud-gcp/1.2.0.M3/reference/html/#inbound-channel-adapter-using-pubsub-streaming-pull)).