### PR TITLE
Bump dep versions for Boot and Spring Cloud GCP

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 :spring_version: current
-:spring_boot_version: 2.2.1.RELEASE
+:spring_boot_version: 2.2.10.RELEASE
 :Controller: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
 :DispatcherServlet: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
 :SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
@@ -64,7 +64,7 @@ Or, if you're using Gradle:
 ```
 dependencies {
     ...
-    compile("org.springframework.cloud:spring-cloud-gcp-starter-pubsub:1.1.3.RELEASE")
+    compile("org.springframework.cloud:spring-cloud-gcp-starter-pubsub:1.2.5.RELEASE")
     compile("org.springframework.integration:spring-integration-core")
     ...
 }
@@ -76,7 +76,7 @@ materials to control the versions of your dependencies:
 ```
 <properties>
     ...
-    <spring-cloud-gcp.version>1.1.3.RELEASE</spring-cloud-gcp.version>
+    <spring-cloud-gcp.version>1.2.5.RELEASE</spring-cloud-gcp.version>
     ...
 </properties>
 

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.2.1.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.2.10.RELEASE")
     }
 }
 
@@ -27,7 +27,7 @@ targetCompatibility = 1.8
 
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-web")
-    compile("org.springframework.cloud:spring-cloud-gcp-starter-pubsub:1.1.3.RELEASE")
+    compile("org.springframework.cloud:spring-cloud-gcp-starter-pubsub:1.2.5.RELEASE")
     compile("org.springframework.integration:spring-integration-core")
     testCompile("org.springframework.boot:spring-boot-starter-test")
 }

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -11,8 +11,8 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <spring-cloud-gcp.version>1.1.3.RELEASE</spring-cloud-gcp.version>
-        <spring-boot-release.version>2.2.1.RELEASE</spring-boot-release.version>
+        <spring-cloud-gcp.version>1.2.5.RELEASE</spring-cloud-gcp.version>
+        <spring-boot-release.version>2.2.10.RELEASE</spring-boot-release.version>
     </properties>
 
     <dependencies>

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.2.1.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.2.10.RELEASE")
     }
 }
 

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <spring-boot-release.version>2.2.1.RELEASE</spring-boot-release.version>
+        <spring-boot-release.version>2.2.10.RELEASE</spring-boot-release.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Spring Cloud GCP: 1.1.3 -> 1.2.5
Spring Boot: 2.2.1 -> 2.2.10